### PR TITLE
Add option to install bookmarklet directly from source in `code.js`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules
+package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ A rather torturous and [elongated struggle with ChatGPT](https://chat.openai.com
 ## notes
 - this script is largely untested and probably unreliable. My hope is someone who can actually write/understand JavaScript will improve it.
 - thanks to [@brothercake](https://github.com/brothercake) for his contrutions
+
+## Development
+1. Install dependencies using [Node](https://nodejs.org) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) (or [Yarn](https://yarnpkg.com/) - _untested_).
+```
+npm i
+```
+2. Run the dev server (http://localhost:8080):
+```
+npm start
+```

--- a/code.js
+++ b/code.js
@@ -1,6 +1,7 @@
 // Self-invoking function to prevent polluting the global namespace
+export default function targetSizeBookmarkletSource () {
 (function () {
-  // Function to get the center of an element
+  /* Function to get the center of an element */
   function getCenter(el) {
     const rect = el.getBoundingClientRect();
     return {
@@ -9,7 +10,7 @@
     };
   }
 
-  // Function to check if an element or its ancestors are hidden
+  /* Function to check if an element or its ancestors are hidden */
   function isVisible(el) {
     let current = el;
     while (current) {
@@ -23,13 +24,13 @@
   }
 
   const SVG_NS = 'http://www.w3.org/2000/svg';
-  
-  // Get all interactive elements that are visible
+
+  /* Get all interactive elements that are visible */
   const elements = [...document.querySelectorAll('a, label, button, input:not([type=hidden]), select, textarea, [tabindex], [role=button], [role=checkbox], [role=link], [role=menuitem], [role=option], [role=radio], [role=switch], [role=tab]')].filter(isVisible);
-  
+
   const centers = [];
 
-  // Iterate through all interactive elements to find their centers and create SVG circles around them
+  /* Iterate through all interactive elements to find their centers and create SVG circles around them */
   elements.forEach(el => {
     if(!el.matches('label') && el.closest('label')) { return; }
 
@@ -72,7 +73,7 @@
 
   const overlaps = [];
 
-  // Check for overlapping elements
+  /* Check for overlapping elements */
   centers.forEach((item1, index) => {
     centers.slice(index + 1).forEach(item2 => {
       if (Math.sqrt(Math.pow(item2.center.left - item1.center.left, 2) + Math.pow(item2.center.top - item1.center.top, 2)) < 24) {
@@ -82,10 +83,11 @@
     });
   });
 
-  // Remove duplicates and set aria-description to 'overlap'
+  /* Remove duplicates and set aria-description to 'overlap' */
   const uniqueOverlaps = [...new Set(overlaps)];
   uniqueOverlaps.forEach(el => el.setAttribute('aria-description', 'overlap'));
 
-  // Alert the user about the number of overlapping elements
+  /* Alert the user about the number of overlapping elements */
   alert(`There are ${uniqueOverlaps.length} overlapping controls.`);
 })();
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en" class="my-bm-page">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <link rel="stylesheet" href="https://nfreear.github.io/elements/src/style/my-bookmarklet.css">
+
+  <title>Target size bookmarklet</title>
+
+  <h1>Target size bookmarklet</h1>
+
+  <p>
+    Scripted aid to identifying overlapping targets. It is meant to help test WCAG 2.2 Success Criterion
+    <a href="https://www.w3.org/TR/WCAG22/#target-size-minimum">2.5.8 Target Size (Minimum)</a>.
+    (<a href="https://github.com/stevefaulkner/targetsize">Source on GitHub</a>)
+  </p>
+
+  <p>
+    <my-bookmarklet name="Target size">Loading…</my-bookmarklet>
+  </p>
+
+  <script type="importmap">
+  {
+    "imports": {
+      "local:bookmarkletSource": "./code.js",
+      "ghp:my-bookmarklet": "https://nfreear.github.io/elements/i.js",
+      "unpkg:my-bookmarklet": "https://unpkg.com/ndf-elements@^1/i.js"
+    },
+    "myElements": {
+      "use": [ "my-bookmarklet" ]
+    }
+  }
+  </script>
+
+  <script type="module">
+    import 'ghp:my-bookmarklet';
+    import bookmarkletSource from 'local:bookmarkletSource';
+
+    const bookmarkletElement = document.querySelector('my-bookmarklet');
+    bookmarkletElement.fromFunction(bookmarkletSource);
+  </script>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "devDependencies": {
+    "servor": "^4.0.2"
+  },
+  "scripts": {
+    "start": "servor"
+  }
+}


### PR DESCRIPTION
Hi Steve,

This pull request does has a few components:

1. The self-invoking function in [`code.js`](https://github.com/nfreear/targetsize/blob/main/code.js) is encapsulated inside an ESM exported function.
2. The [web page](https://github.com/nfreear/targetsize/blob/main/index.html) uses a `<my-bookmarklet>` custom element to extract the source from the exported/imported function in `code.js` above, and makes it available in an `<a href>` link, in uncompressed form.

This would allow the bookmarklet to be hosted, for example, on GitHub Pages, or any web-site.

You can see a demo of `<my-bookmarklet>` in use in [this CodePen](https://codepen.io/nfreear/pen/XJWWLpm).

Useful?

Best wishes,


Nick
